### PR TITLE
Add _DARKMODELIB_EXTERNAL_DPI to let the host provide the DPI layer

### DIFF
--- a/src/DmlibDpi.cpp
+++ b/src/DmlibDpi.cpp
@@ -23,6 +23,13 @@
 
 #include "ModuleHelper.h"
 
+// When _DARKMODELIB_EXTERNAL_DPI is defined, the host application provides the
+// dmlib_dpi function implementations (e.g. by reusing DPI functions it has
+// already resolved), so this translation unit is compiled out to avoid loading
+// the same system functions twice. See DmlibDpi.h for the list of functions the
+// host must then define.
+#ifndef _DARKMODELIB_EXTERNAL_DPI
+
 extern "C"
 {
 	static UINT WINAPI DummyGetDpiForSystem() noexcept
@@ -228,3 +235,5 @@ DWORD dmlib_dpi::getTextScaleFactor() noexcept
 	}
 	return defaultVal;
 }
+
+#endif // !defined(_DARKMODELIB_EXTERNAL_DPI)

--- a/src/DmlibDpi.h
+++ b/src/DmlibDpi.h
@@ -51,6 +51,20 @@ namespace dmlib_dpi
 	inline constexpr UINT kDefaultFontDpi = 72;
 	inline constexpr UINT kDefaultFontScaleFactor = 100;
 
+	/**
+	 * @brief Wrappers around the per-monitor DPI v2 system API.
+	 *
+	 * By default the non-inline functions declared below are implemented in
+	 * DmlibDpi.cpp, which resolves the underlying system functions dynamically
+	 * (with fallbacks for systems older than Windows 10).
+	 *
+	 * If the macro `_DARKMODELIB_EXTERNAL_DPI` is defined, DmlibDpi.cpp is
+	 * compiled out and the host application must provide the definitions of
+	 * these non-inline functions. This avoids resolving the DPI functions twice
+	 * when the host already loads them itself (for example an application that
+	 * ships its own DPI helper layer). The inline helpers in this header are
+	 * unaffected and keep working on top of the host-provided functions.
+	 */
 	bool InitDpiAPI() noexcept;
 
 	[[nodiscard]] UINT GetDpiForSystem() noexcept;


### PR DESCRIPTION
## Motivation

`DmlibDpi.cpp` dynamically resolves the per-monitor DPI v2 functions
(`GetDpiForWindow`, `GetSystemMetricsForDpi`, `AdjustWindowRectExForDpi`,
`GetDpiForSystem`, …) via `GetProcAddress`, with fallbacks for systems older
than Windows 10.

Applications that **already** resolve these functions themselves end up loading
them a second time. For example, Notepad4 loads them through Scintilla's
`Scintilla_LoadDpiForWindow()` and exposes them via its own DPI helpers, so the
vendored copy of darkmodelib duplicates that work.

## Change

Add an opt-in `_DARKMODELIB_EXTERNAL_DPI` macro:

- When **undefined** (default), behavior is exactly as before.
- When **defined**, `DmlibDpi.cpp` is compiled out and the host application
  provides the implementations of the non-inline `dmlib_dpi` functions declared
  in `DmlibDpi.h`. The inline helpers in the header are unchanged and keep
  working on top of the host-provided functions, so existing code that uses
  `dmlib_dpi` compiles unmodified.

The macro follows the same inline-documented, opt-in style as the existing
`_DARKMODELIB_NO_INI_CONFIG` / `_DARKMODELIB_ALLOW_OLD_OS` macros.

## Verification

Built `vs.proj/darkmodelib.vcxproj` (x64 Release) both ways:

- macro undefined — full implementation compiles as before;
- macro defined — `DmlibDpi.cpp` compiles to an empty translation unit and the
  static library archives cleanly.

Also validated end-to-end in Notepad4, which supplies the `dmlib_dpi` layer from
its existing DPI helpers and builds for both the Windows 10 and the
Vista/Windows 7 targets.

I'm happy to adjust the granularity (e.g. externalize only a subset of the
functions) if you'd prefer a different scope.
