### PR TITLE
Use local buffers in Win32 callbacks to avoid throwing STL

### DIFF
--- a/src/Darkmodelib.cpp
+++ b/src/Darkmodelib.cpp
@@ -2273,7 +2273,7 @@ static void setMonthCalendarCtrlTheme(HWND hWnd, DarkModeParams p) noexcept
 static BOOL CALLBACK DarkEnumChildProc(HWND hWnd, LPARAM lParam)
 {
 	const auto& p = *reinterpret_cast<DarkModeParams*>(lParam);
-	const std::wstring className = dmlib_subclass::getWndClassName(hWnd);
+	const auto className = dmlib_subclass::getWndClassName(hWnd);
 
 	if (className == WC_BUTTON)
 	{

--- a/src/DmlibSubclass.h
+++ b/src/DmlibSubclass.h
@@ -18,7 +18,9 @@
 
 #include <algorithm>
 #include <array>
+#include <cwchar>
 #include <memory>
+#include <new>
 #include <string>
 #include <string_view>
 #include <type_traits>
@@ -74,12 +76,16 @@ namespace dmlib_subclass
 		if (const auto subclassID = static_cast<UINT_PTR>(subID);
 			::GetWindowSubclass(hWnd, subclassProc, subclassID, nullptr) == FALSE)
 		{
-			if (auto pData = std::make_unique<T>(param);
-				::SetWindowSubclass(hWnd, subclassProc, subclassID, reinterpret_cast<DWORD_PTR>(pData.get())) == TRUE)
+			T* pData = new (std::nothrow) T(param);
+			if (pData == nullptr)
 			{
-				pData.release();
+				return FALSE;
+			}
+			if (::SetWindowSubclass(hWnd, subclassProc, subclassID, reinterpret_cast<DWORD_PTR>(pData)) == TRUE)
+			{
 				return TRUE;
 			}
+			delete pData;
 			return FALSE;
 		}
 		return -1;
@@ -102,12 +108,16 @@ namespace dmlib_subclass
 		if (const auto subclassID = static_cast<UINT_PTR>(subID);
 			::GetWindowSubclass(hWnd, subclassProc, subclassID, nullptr) == FALSE)
 		{
-			if (auto pData = std::make_unique<T>();
-				::SetWindowSubclass(hWnd, subclassProc, subclassID, reinterpret_cast<DWORD_PTR>(pData.get())) == TRUE)
+			T* pData = new (std::nothrow) T();
+			if (pData == nullptr)
 			{
-				pData.release();
+				return FALSE;
+			}
+			if (::SetWindowSubclass(hWnd, subclassProc, subclassID, reinterpret_cast<DWORD_PTR>(pData)) == TRUE)
+			{
 				return TRUE;
 			}
+			delete pData;
 			return FALSE;
 		}
 		return -1;
@@ -368,22 +378,46 @@ namespace dmlib_subclass
 	};
 
 	/**
+	 * @brief Holds a window class name in a fixed-size buffer.
+	 *
+	 * Window class names are limited in length and the standard control classes
+	 * are short, so a small fixed buffer avoids the heap allocation (and the
+	 * possible `std::bad_alloc`) of `std::wstring` when querying a class name
+	 * inside a Win32 callback.
+	 */
+	struct WndClassName
+	{
+		static constexpr int kMaxLength = 32;
+		wchar_t data[kMaxLength];
+	};
+
+	[[nodiscard]] inline bool operator==(const WndClassName& lhs, const wchar_t* rhs) noexcept
+	{
+		return ::wcscmp(lhs.data, rhs) == 0;
+	}
+
+	[[nodiscard]] inline bool operator!=(const WndClassName& lhs, const wchar_t* rhs) noexcept
+	{
+		return ::wcscmp(lhs.data, rhs) != 0;
+	}
+
+	/**
 	 * @brief Retrieves the class name of a given window.
 	 *
-	 * This function wraps the Win32 API `GetClassNameW` to return the class name
-	 * of a window as a wide string (`std::wstring`).
+	 * Wraps the Win32 API `GetClassNameW`, returning the result in a fixed-size
+	 * buffer so that the call does not allocate and cannot throw when used
+	 * inside a Win32 callback.
 	 *
 	 * @param[in] hWnd Handle to the target window.
-	 * @return The class name of the window as a `std::wstring`.
+	 * @return The class name of the window.
 	 *
 	 * @note The maximum length is capped at 32 characters (including the null terminator),
 	 *       which suffices for standard Windows window classes.
 	 */
-	[[nodiscard]] inline std::wstring getWndClassName(HWND hWnd)
+	[[nodiscard]] inline WndClassName getWndClassName(HWND hWnd) noexcept
 	{
-		static constexpr int strLen = 32;
-		auto className = std::wstring(strLen, L'\0');
-		className.resize(static_cast<size_t>(::GetClassNameW(hWnd, className.data(), strLen)));
+		WndClassName className{};
+		::GetClassNameW(hWnd, className.data, WndClassName::kMaxLength);
 		return className;
 	}
 
@@ -408,6 +442,55 @@ namespace dmlib_subclass
 		}
 		return (dmlib_subclass::getWndClassName(hWnd) == classNameToCmp);
 	}
+
+	/**
+	 * @brief Fixed-capacity text buffer with a non-throwing heap fallback.
+	 *
+	 * Provides an inline stack buffer for the common (short) case and falls back
+	 * to a `new (std::nothrow)` allocation for longer strings. Retrieving control
+	 * text inside a Win32 callback therefore never throws `std::bad_alloc` the
+	 * way a `std::wstring` scratch buffer would. On allocation failure the buffer
+	 * keeps its inline capacity, so callers always get a valid (possibly
+	 * truncated) null-terminated buffer.
+	 */
+	class TextBuffer
+	{
+	public:
+		explicit TextBuffer(size_t length) noexcept
+		{
+			if (length > kStackCapacity)
+			{
+				m_heap = new (std::nothrow) wchar_t[length];
+				if (m_heap != nullptr)
+				{
+					m_ptr = m_heap;
+					m_capacity = length;
+				}
+			}
+			m_ptr[0] = L'\0';
+		}
+
+		~TextBuffer()
+		{
+			delete[] m_heap;
+		}
+
+		TextBuffer(const TextBuffer&) = delete;
+		TextBuffer& operator=(const TextBuffer&) = delete;
+		TextBuffer(TextBuffer&&) = delete;
+		TextBuffer& operator=(TextBuffer&&) = delete;
+
+		[[nodiscard]] wchar_t* data() noexcept { return m_ptr; }
+		[[nodiscard]] const wchar_t* data() const noexcept { return m_ptr; }
+		[[nodiscard]] int capacity() const noexcept { return static_cast<int>(m_capacity); }
+
+	private:
+		static constexpr size_t kStackCapacity = 256;
+		wchar_t m_stack[kStackCapacity];
+		wchar_t* m_heap = nullptr;
+		wchar_t* m_ptr = m_stack;
+		size_t m_capacity = kStackCapacity;
+	};
 
 	/// Determines if themed styling should be preferred over subclassing.
 	[[nodiscard]] bool isThemePrefered() noexcept;

--- a/src/DmlibSubclassControl.cpp
+++ b/src/DmlibSubclassControl.cpp
@@ -138,8 +138,8 @@ static void renderButton(
 	::GetClientRect(hWnd, &rcClient);
 
 	const auto bufferLen = static_cast<size_t>(::GetWindowTextLengthW(hWnd));
-	auto buffer = std::wstring(bufferLen + 1, L'\0');
-	::GetWindowTextW(hWnd, buffer.data(), static_cast<int>(buffer.length()));
+	dmlib_subclass::TextBuffer buffer(bufferLen + 1);
+	::GetWindowTextW(hWnd, buffer.data(), buffer.capacity());
 
 	SIZE szBox{};
 	::GetThemePartSize(hTheme, hdc, iPartID, iStateID, nullptr, TS_DRAW, &szBox);
@@ -164,7 +164,7 @@ static void renderButton(
 	dtto.dwFlags = DTT_TEXTCOLOR;
 	dtto.crText = (::IsWindowEnabled(hWnd) == FALSE) ? dmlib::getDisabledTextColor() : dmlib::getTextColor();
 
-	::DrawThemeTextEx(hTheme, hdc, iPartID, iStateID, buffer.c_str(), -1, dtFlags, &rcText, &dtto);
+	::DrawThemeTextEx(hTheme, hdc, iPartID, iStateID, buffer.data(), -1, dtFlags, &rcText, &dtto);
 
 	// Focus rect
 
@@ -172,7 +172,7 @@ static void renderButton(
 	if (((nState & BST_FOCUS) == BST_FOCUS) && ((uiState & UISF_HIDEFOCUS) != UISF_HIDEFOCUS))
 	{
 		dtto.dwFlags |= DTT_CALCRECT;
-		::DrawThemeTextEx(hTheme, hdc, iPartID, iStateID, buffer.c_str(), -1, dtFlags | DT_CALCRECT, &rcText, &dtto);
+		::DrawThemeTextEx(hTheme, hdc, iPartID, iStateID, buffer.data(), -1, dtFlags | DT_CALCRECT, &rcText, &dtto);
 		const RECT rcFocus{ rcText.left - 1, rcText.top, rcText.right + 1, rcText.bottom + 1 };
 		::DrawFocusRect(hdc, &rcFocus);
 	}
@@ -527,12 +527,11 @@ static void paintGroupbox(HWND hWnd, HDC hdc, const dmlib_subclass::ButtonData& 
 
 	// Text rectangle part
 
-	std::wstring buffer;
 	const auto bufferLen = static_cast<size_t>(::GetWindowTextLengthW(hWnd));
+	dmlib_subclass::TextBuffer buffer(bufferLen + 1);
 	if (bufferLen > 0)
 	{
-		buffer.resize(bufferLen + 1, L'\0');
-		::GetWindowTextW(hWnd, buffer.data(), static_cast<int>(buffer.length()));
+		::GetWindowTextW(hWnd, buffer.data(), buffer.capacity());
 	}
 
 	const auto nStyle = ::GetWindowLongPtr(hWnd, GWL_STYLE);
@@ -545,10 +544,10 @@ static void paintGroupbox(HWND hWnd, HDC hdc, const dmlib_subclass::ButtonData& 
 
 	RECT rcText{ rcClient };
 	RECT rcBackground{ rcClient };
-	if (!buffer.empty())
+	if (bufferLen != 0)
 	{
 		SIZE szText{};
-		::GetTextExtentPoint32W(hdc, buffer.c_str(), static_cast<int>(bufferLen), &szText);
+		::GetTextExtentPoint32W(hdc, buffer.data(), static_cast<int>(bufferLen), &szText);
 
 		const int centerPosX = isCenter ? ((rcClient.right - rcClient.left - szText.cx) / 2) : 7;
 
@@ -576,7 +575,7 @@ static void paintGroupbox(HWND hWnd, HDC hdc, const dmlib_subclass::ButtonData& 
 
 	// Text part
 
-	if (!buffer.empty())
+	if (bufferLen != 0)
 	{
 		::InflateRect(&rcText, -2, 0);
 
@@ -592,7 +591,7 @@ static void paintGroupbox(HWND hWnd, HDC hdc, const dmlib_subclass::ButtonData& 
 			dtFlags |= DT_HIDEPREFIX;
 		}
 
-		::DrawThemeTextEx(hTheme, hdc, BP_GROUPBOX, iStateID, buffer.c_str(), -1, dtFlags | DT_SINGLELINE, &rcText, &dtto);
+		::DrawThemeTextEx(hTheme, hdc, BP_GROUPBOX, iStateID, buffer.data(), -1, dtFlags | DT_SINGLELINE, &rcText, &dtto);
 	}
 }
 
@@ -925,8 +924,8 @@ static void paintArrow(
 	std::array<POINT, 3> ptsArrow{};
 	for (size_t i = 0; i < 3; ++i)
 	{
-		ptsArrow.at(i).x = static_cast<LONG>((ptsArrowSelected.at(i).x * sizeArrow.x) + xPos);
-		ptsArrow.at(i).y = static_cast<LONG>((ptsArrowSelected.at(i).y * sizeArrow.y) + yPos);
+		ptsArrow[i].x = static_cast<LONG>((ptsArrowSelected[i].x * sizeArrow.x) + xPos);
+		ptsArrow[i].y = static_cast<LONG>((ptsArrowSelected[i].y * sizeArrow.y) + yPos);
 	}
 
 	const auto hBrush = dmlib_paint::GdiObject{ hdc, ::CreateSolidBrush(clr) };
@@ -1325,11 +1324,11 @@ static void paintTabItem(
 	::InflateRect(&rcItem, -1, -1);
 	rcItem.right += 1;
 
-	auto buffer = std::wstring(MAX_PATH, L'\0'); // label
+	wchar_t buffer[MAX_PATH]{}; // label
 	TCITEMW tci{};
 	tci.mask = TCIF_TEXT | TCIF_IMAGE | TCIF_STATE;
 	tci.dwStateMask = TCIS_HIGHLIGHTED;
-	tci.pszText = buffer.data();
+	tci.pszText = buffer;
 	tci.cchTextMax = MAX_PATH - 1;
 
 	TabCtrl_GetItem(hWnd, i, &tci);
@@ -1404,7 +1403,7 @@ static void paintTabItem(
 		dmlib_paint::paintRect(hdc, rcHighlightLine, dmlib::getHighlightPen(), dmlib::getHighlightBrush());
 	}
 
-	::DrawText(hdc, buffer.c_str(), -1, &rcText, DT_CENTER | DT_VCENTER | DT_SINGLELINE);
+	::DrawText(hdc, buffer, -1, &rcText, DT_CENTER | DT_VCENTER | DT_SINGLELINE);
 
 	// Draw focus keyboard cue
 	if (!isSelectedTab || ::GetFocus() != hWnd)
@@ -2123,7 +2122,7 @@ static void renderComboBoxList(
 		else
 		{
 			const auto bufferLen = static_cast<size_t>(::SendMessage(hWnd, CB_GETLBTEXTLEN, static_cast<WPARAM>(index), 0));
-			auto buffer = std::wstring(bufferLen + 1, L'\0');
+			dmlib_subclass::TextBuffer buffer(bufferLen + 1);
 			::SendMessage(hWnd, CB_GETLBTEXT, static_cast<WPARAM>(index), reinterpret_cast<LPARAM>(buffer.data()));
 
 			RECT rcText{ cbi.rcItem };
@@ -2137,13 +2136,13 @@ static void renderComboBoxList(
 				dtto.dwFlags = DTT_TEXTCOLOR;
 				dtto.crText = clrText;
 
-				::DrawThemeTextEx(hTheme, hdc, CP_DROPDOWNITEM, iStateID, buffer.c_str(), -1, dtFlags, &rcText, &dtto);
+				::DrawThemeTextEx(hTheme, hdc, CP_DROPDOWNITEM, iStateID, buffer.data(), -1, dtFlags, &rcText, &dtto);
 			}
 			else
 			{
 				::SetTextColor(hdc, clrText);
 				::SetBkMode(hdc, TRANSPARENT);
-				::DrawText(hdc, buffer.c_str(), -1, &rcText, dtFlags);
+				::DrawText(hdc, buffer.data(), -1, &rcText, dtFlags);
 			}
 		}
 	}
@@ -2713,10 +2712,10 @@ static void paintHeaderItem(
 		::FillRect(hdc, &rcTmp, dmlib::getHeaderHotBackgroundBrush());
 	}
 
-	auto buffer = std::wstring(MAX_PATH, L'\0');
+	wchar_t buffer[MAX_PATH]{};
 	HDITEM hdi{};
 	hdi.mask = HDI_TEXT | HDI_FORMAT;
-	hdi.pszText = buffer.data();
+	hdi.pszText = buffer;
 	hdi.cchTextMax = MAX_PATH - 1;
 
 	Header_GetItem(hWnd, i, &hdi);
@@ -3080,7 +3079,6 @@ static void paintStatusBar(HWND hWnd, HDC hdc, dmlib_subclass::StatusBarData& st
 	::FillRect(hdc, &rcClient, dmlib::getBackgroundBrush());
 
 	const auto nParts = static_cast<int>(::SendMessage(hWnd, SB_GETPARTS, 0, 0));
-	std::wstring str;
 	RECT rcPart{};
 	RECT rcIntersect{};
 	// no edge before size grip
@@ -3110,7 +3108,7 @@ static void paintStatusBar(HWND hWnd, HDC hdc, dmlib_subclass::StatusBarData& st
 		const LRESULT retValLen = ::SendMessage(hWnd, SB_GETTEXTLENGTH, static_cast<WPARAM>(i), 0);
 		const DWORD cchText = LOWORD(retValLen);
 
-		str.resize(static_cast<size_t>(cchText) + 1);
+		dmlib_subclass::TextBuffer str(static_cast<size_t>(cchText) + 1);
 		const LRESULT retValText = ::SendMessage(hWnd, SB_GETTEXT, static_cast<WPARAM>(i), reinterpret_cast<LPARAM>(str.data()));
 
 		// With `SBT_OWNERDRAW` flag parent will draw status bar.
@@ -3133,7 +3131,7 @@ static void paintStatusBar(HWND hWnd, HDC hdc, dmlib_subclass::StatusBarData& st
 		}
 		else
 		{
-			::DrawText(hdc, str.c_str(), -1, &rcPart, DT_SINGLELINE | DT_VCENTER | DT_LEFT);
+			::DrawText(hdc, str.data(), -1, &rcPart, DT_SINGLELINE | DT_VCENTER | DT_LEFT);
 		}
 	}
 

--- a/src/DmlibSubclassWindow.cpp
+++ b/src/DmlibSubclassWindow.cpp
@@ -102,7 +102,7 @@ static LRESULT onCtlColorStaticHelper(LPARAM lParam, WPARAM wParam)
 	auto hChild = reinterpret_cast<HWND>(lParam);
 
 	const bool isChildEnabled = ::IsWindowEnabled(hChild) == TRUE;
-	const std::wstring className = dmlib_subclass::getWndClassName(hChild);
+	const auto className = dmlib_subclass::getWndClassName(hChild);
 
 	if (className == WC_EDIT)
 	{
@@ -966,7 +966,7 @@ static LRESULT onNotifyCustomDrawOrDTPDropDown(
 	auto* lpnmhdr = reinterpret_cast<LPNMHDR>(lParam);
 	if (lpnmhdr->code == NM_CUSTOMDRAW)
 	{
-		const std::wstring className = dmlib_subclass::getWndClassName(lpnmhdr->hwndFrom);
+		const auto className = dmlib_subclass::getWndClassName(lpnmhdr->hwndFrom);
 
 		if (className == TOOLBARCLASSNAME)
 		{
@@ -1120,11 +1120,11 @@ static void paintMenuBar(HWND hWnd, HDC hdc) noexcept
 static void paintMenuBarItems(UAHDRAWMENUITEM& UDMI, const HTHEME& hTheme)
 {
 	// get the menu item string
-	auto buffer = std::wstring(MAX_PATH, L'\0');
+	wchar_t buffer[MAX_PATH]{};
 	MENUITEMINFO mii{};
 	mii.cbSize = sizeof(MENUITEMINFO);
 	mii.fMask = MIIM_STRING;
-	mii.dwTypeData = buffer.data();
+	mii.dwTypeData = buffer;
 	mii.cch = MAX_PATH - 1;
 
 	::GetMenuItemInfoW(UDMI.um.hmenu, static_cast<UINT>(UDMI.umi.iPosition), TRUE, &mii);
@@ -1224,7 +1224,7 @@ static void paintMenuBarItems(UAHDRAWMENUITEM& UDMI, const HTHEME& hTheme)
 		}
 	}
 
-	::DrawThemeTextEx(hTheme, UDMI.um.hdc, MENU_BARITEM, iTextStateID, buffer.c_str(), static_cast<int>(mii.cch), dwFlags, &UDMI.dis.rcItem, &dttopts);
+	::DrawThemeTextEx(hTheme, UDMI.um.hdc, MENU_BARITEM, iTextStateID, buffer, static_cast<int>(mii.cch), dwFlags, &UDMI.dis.rcItem, &dttopts);
 }
 
 /**
@@ -1521,7 +1521,7 @@ static LRESULT CALLBACK DarkTaskDlgSubclass(
 
 		case WM_ERASEBKGND:
 		{
-			const std::wstring className = dmlib_subclass::getWndClassName(hWnd);
+			const auto className = dmlib_subclass::getWndClassName(hWnd);
 
 			if (className == L"CtrlNotifySink")
 			{
@@ -1581,7 +1581,7 @@ static void setDarkTaskDlgSubclass(HWND hWnd)
  */
 static BOOL CALLBACK DarkTaskEnumChildProc(HWND hWnd, [[maybe_unused]] LPARAM lParam)
 {
-	const std::wstring className = dmlib_subclass::getWndClassName(hWnd);
+	const auto className = dmlib_subclass::getWndClassName(hWnd);
 
 	if (className == L"CtrlNotifySink")
 	{


### PR DESCRIPTION
## Motivation

Several Win32 callback / paint code paths use STL types that may allocate
(`std::wstring` scratch buffers, `std::make_unique`, `std::array::at()`). If one
of those throws (e.g. `std::bad_alloc`), the exception escapes through the
OS-owned callback frame, which `bugprone-exception-escape` flags.

## Change

Replace the throwing STL with non-throwing local buffers:

- **`getWndClassName()`** returns a fixed-size `WndClassName` buffer (with `==` /
  `!=` against a wide string) instead of `std::wstring`. Class names are short
  and length-capped, so no allocation is needed. Call sites are unchanged except
  for the buffer type.
- **`TextBuffer`** — a small helper with an inline stack buffer and a
  `new (std::nothrow)` heap fallback — backs the variable-length
  `GetWindowText` / `CB_GETLBTEXT` / `SB_GETTEXT` scratch buffers. The fixed
  `MAX_PATH` tab/header/menu buffers become plain `wchar_t[MAX_PATH]` arrays.
- **`SetSubclass()`** allocates with `new (std::nothrow)` instead of
  `std::make_unique`, returning `FALSE` on allocation failure instead of
  throwing.
- The up/down arrow paint uses `operator[]` instead of `std::array::at()`.

Behavior is unchanged; on the (extremely unlikely) allocation failure the code
now degrades gracefully instead of throwing.

## Verification

- The solution builds and links (static lib, DLL and both demos), x64 Release.
- `clang-tidy -checks=-*,bugprone-exception-escape` reports no findings on the
  modified callback files (`DmlibSubclassControl.cpp`, `DmlibSubclassWindow.cpp`,
  `Darkmodelib.cpp`).

Independent of #23 (external DPI); this PR only touches the callback buffers.
